### PR TITLE
More information on Keyword Specs

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,18 +40,10 @@ var buildCommand = function(opt) {
             }
 
             if (keyword.plural) {
-                if (keyword.singular) {
-                    throw new gutil.PluginError('gulp-xgettext', '"plural" cannot be set with "singular"');
-                }
-
                 args.push(keyword.plural);
             }
 
             if (keyword.context) {
-                if (keyword.singular) {
-                    throw new gutil.PluginError('gulp-xgettext', '"context" cannot be set with "singular"');
-                }
-
                 args.push(keyword.context + 'c');
             }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var buildCommand = function(opt) {
             var keyword = opt.keywords[i],
                 args = [];
             if (!keyword.name || (typeof keyword.name !== 'string')) {
-                throw new gutil.PluginError('gulp-xgettext', 'Name of a keyword must be a not empty string')
+                throw new gutil.PluginError('gulp-xgettext', 'Name of a keyword must be an not empty string')
             }
 
             if (keyword.singular) {
@@ -34,7 +34,7 @@ var buildCommand = function(opt) {
 
             if (keyword.plural) {
                 if (keyword.singular) {
-                    throw new gutil.PluginError('gulp-xgettext', '"plural" cannot be set without "singular"');
+                    throw new gutil.PluginError('gulp-xgettext', '"plural" cannot be set with "singular"');
                 }
 
                 args.push(keyword.plural);
@@ -42,7 +42,7 @@ var buildCommand = function(opt) {
 
             if (keyword.context) {
                 if (keyword.singular) {
-                    throw new gutil.PluginError('gulp-xgettext', '"context" cannot be set without "singular"');
+                    throw new gutil.PluginError('gulp-xgettext', '"context" cannot be set with "singular"');
                 }
 
                 args.push(keyword.context + 'c');

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ var buildCommand = function(opt) {
         for (var i = 0, l = opt.keywords.length; i < l; i++) {
             var keyword = opt.keywords[i],
                 args = [];
+
+            /**
+             * See --keyword section of
+             * http://www.gnu.org/software/gettext/manual/gettext.html#Language-specific-options
+             * for details of all possible keywordspec.
+             */
+
             if (!keyword.name || (typeof keyword.name !== 'string')) {
                 throw new gutil.PluginError('gulp-xgettext', 'Name of a keyword must be an not empty string')
             }


### PR DESCRIPTION
I've updated the error messages and provided information on where to find the keyword spec. There is no restriction on using singular, plural and context arguments together. See the keyword specs for C# for an example.