### PR TITLE
Force UTF-8 to prevent gnu xgettext failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var buildCommand = function(options) {
     var opt = options || {};
     var command = opt.bin || 'xgettext';
 
-    command += ' --force-po -o -';
+    command += ' --from-code="UTF-8" --force-po -o -';
 
     if (opt.language) {
         command += ' --language="' + opt.language + '"';


### PR DESCRIPTION
Noticed on my machine (OSX 10.10 with GNU xgettext 0.19.4 installed via brew) that xgettext was failing. After investigation, turning on `--from-code="UTF-8"` fixed the problem.