### PR TITLE
comments for translators should be supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Type: `String`
 
 Specifies the encoding of the input files. This option is needed only if some untranslated message strings or their corresponding comments contain non-ASCII characters By default the input files are assumed to be in ASCII.
 
+#### options.comments
+
+Type: `String|Boolean`
+
+Reads the comments for translators from the input files and inserts them in the resulting .po file. Using a string as value specifies the ***tag*** of the parameter ``--add-comments[=tag]``, described in [section 5.1.5 of xgettext documentation](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html). An empty string or the boolean value ``true`` will set the parameter ***add-comments*** without a specific tag.
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ var buildCommand = function(options) {
 
     // Use STDIN as input
     command += ' -';
-console.log(command);
+
     return command;
 };
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var buildCommand = function(options) {
         command += ' --from-code="' + opt.encoding + '"';
     }
 
-    if ((opt.comments === '') || (opt.comments === true)) {
+    if (opt.comments === true) {
         command += ' --add-comments';
     } else if (typeof opt.comments == 'string') {
         command += ' --add-comments="' + opt.comments + '"';
@@ -68,7 +68,7 @@ var buildCommand = function(options) {
 
     // Use STDIN as input
     command += ' -';
-
+console.log(command);
     return command;
 };
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ var buildCommand = function(options) {
         command += ' --from-code="' + opt.encoding + '"';
     }
 
+    if ((opt.comments === '') || (opt.comments === true)) {
+        command += ' --add-comments';
+    } else if (typeof opt.comments == 'string') {
+        command += ' --add-comments="' + opt.comments + '"';
+    }
+
     if (opt.keywords) {
         for (var i = 0, l = opt.keywords.length; i < l; i++) {
             var keyword = opt.keywords[i],


### PR DESCRIPTION
Comments for translators should be optionally extracted from sourcecode.

For this xgettext uses the parameter ``--add-comments[=tag]``. The plugin could provide an ``option.comments``. If it's set as string, this will be used as the ***tag*** value for the parameter, which specifies the keyword for translator comments. An empty string or the boolean value ``true`` will set the parameter without a specific tag and parse all comments preceding keyword lines.